### PR TITLE
Base64 support filebox related to issue #83

### DIFF
--- a/wechaty-puppet/src/main/kotlin/io/github/wechaty/filebox/FileBox.kt
+++ b/wechaty-puppet/src/main/kotlin/io/github/wechaty/filebox/FileBox.kt
@@ -138,13 +138,13 @@ class FileBox(options: FileBoxOptions) {
     }
 
     fun toJsonString(): String {
-        buffer = toByte(this)
+        buffer = getBufferByte(this)
 
         return JsonUtils.write(this)
 
     }
 
-    fun toByte(fileBox: FileBox): ByteArray? {
+    fun getBufferByte(fileBox: FileBox): ByteArray? {
         when (fileBox.type()) {
             FileBoxType.File -> {
 
@@ -153,11 +153,12 @@ class FileBox(options: FileBoxOptions) {
                 return FileUtils.readFileToByteArray(file)
 
             }
-
             FileBoxType.Url -> {
                 return null;
             }
-
+            FileBoxType.Base64 -> {
+                return null;
+            }
             else -> {
                 TODO()
             }

--- a/wechaty-puppet/src/main/kotlin/io/github/wechaty/filebox/FileBox.kt
+++ b/wechaty-puppet/src/main/kotlin/io/github/wechaty/filebox/FileBox.kt
@@ -144,7 +144,7 @@ class FileBox(options: FileBoxOptions) {
 
     }
 
-    fun getBufferByte(fileBox: FileBox): ByteArray? {
+    private fun getBufferByte(fileBox: FileBox): ByteArray? {
         when (fileBox.type()) {
             FileBoxType.File -> {
 


### PR DESCRIPTION
Related to issue https://github.com/wechaty/java-wechaty/issues/83

To add base64 type filebox, as Donut puppet generates filebox in base64 type